### PR TITLE
Fix: Use sudo to remove TESTDIR in teardown

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -55,7 +55,7 @@ health_checks() {
 teardown() {
   set -eu -o pipefail
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  [ "${TESTDIR}" != "" ] && sudo rm -rf ${TESTDIR}
 }
 
 @test "install from directory" {


### PR DESCRIPTION
The `teardown` function in `tests/test.bats` was failing to remove the TESTDIR due to permission errors. This occurred because files and directories created by Milvus (or other services running within DDEV) were owned by a different user than the one executing the test script.

This commit modifies the `teardown` function to use `sudo rm -rf ${TESTDIR}`. This ensures that the cleanup process has the necessary permissions to remove all files and directories within TESTDIR, regardless of their ownership.

Note: I had to skip testing this change due to insufficient disk space.

## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/iGore/ddev-milvus/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
